### PR TITLE
Improve re-coding

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -280,7 +280,7 @@ load_nhanes_description <- function(file_name, year, destination = tempdir(), ca
 }
 
 recode_nhanes_data <- function(nhanes_data, nhanes_description) {  
-  # Return without changes if there is no encoding information in the codebook
+  # Return without changes if there is no information in the codebook
   if(is.null(nhanes_description)){
     return(nhanes_data)
   }
@@ -289,9 +289,9 @@ recode_nhanes_data <- function(nhanes_data, nhanes_description) {
     val <- nhanes_description[row, "Code or Value"]
     var_name <- nhanes_description[row, "var_name"]
     descr <- nhanes_description[row, "Value Description"]
-    if(var_name %in% names(nhanes_data)){
-      # Sometimes a variable has a description but no matching data, or the variable name differs in data and the codebook
-      nhanes_data[!is.na(nhanes_data[var_name]) & nhanes_data[var_name] %in% val, var_name] <- descr  # use %in% instead of == to avoid missingness error
+    if(var_name %in% names(nhanes_data) & !is.na(val)){
+      # Don't attempt re-coding unless the variable is listed in the data and the value is not NA
+      nhanes_data[!is.na(nhanes_data[var_name]) & (nhanes_data[var_name] == val), var_name] <- descr
     }
   }
   return(nhanes_data)

--- a/R/import.R
+++ b/R/import.R
@@ -291,7 +291,7 @@ recode_nhanes_data <- function(nhanes_data, nhanes_description) {
     descr <- nhanes_description[row, "Value Description"]
     if(var_name %in% names(nhanes_data)){
       # Sometimes a variable has a description but no matching data, or the variable name differs in data and the codebook
-      nhanes_data[nhanes_data[var_name]==val & !is.na(nhanes_data[var_name]), var_name] <- descr
+      nhanes_data[!is.na(nhanes_data[var_name]) & nhanes_data[var_name] %in% val, var_name] <- descr  # use %in% instead of == to avoid missingness error
     }
   }
   return(nhanes_data)


### PR DESCRIPTION
1. Speed

The `recode_nhanes_data` function uses a nested for-loop through the data, which is very slow for some of the larger datasets (like `FFQDC` or `DR1IFF`).  I've rewritten it to loop though the variable descriptions instead, updating all of the matched data at once.

2. Compatibility

In some cases the variable names in the codebook use lowercase letters while the datasets use all capital letters (for example, `OSQ010a`).  The variable description information is now recorded using all-capital variable names.